### PR TITLE
[Idea] Enable Logging for Gunicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 migrate: python manage.py migrate
-web: gunicorn project_name.wsgi
+web: gunicorn project_name.wsgi --log-file -


### PR DESCRIPTION
This change is proposed to conform with the notion that a production-grade application should have an appropriate logging. Since users will not be able to see debugging message if the option is disabled inside Django, the only way to do a debugging in Heroku is by reading the logs. I am proposing that any error logs should be printed to the standard output so errors can be easily identified.

Thank You Syifa Rizka for helping me identify the need for this idea.

Warm regards,
Rafi